### PR TITLE
Add npx to the build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "resolve-from": "^5.0.0"
   },
   "scripts": {
-    "build": "ts-node lib",
+    "build": "npx ts-node lib",
     "build:css": "npx tailwindcss -i ./styles.css -o ./public/styles.css --minify",
     "deploy": "npx vercel deploy --prebuilt"
   }


### PR DESCRIPTION
Hey, I noticed that the build command does not work if `ts-node` is not installed globally, so I added `npx` to the build command definition.